### PR TITLE
Align title and icon with large font sizes

### DIFF
--- a/d2l-accordion-collapse.html
+++ b/d2l-accordion-collapse.html
@@ -17,6 +17,7 @@
 			}
 			#trigger {
 				@apply --layout-horizontal;
+				@apply --layout-center;
 				text-decoration: none;
 			}
 			#trigger, #trigger:visited, #trigger:hover, #trigger:active {

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 	<head>
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, minimum-scale=1, initial-scale=1, user-scalable=yes">
-		<title>d2l-accordian</title>
+		<title>d2l-accordion</title>
 		<script src="../webcomponentsjs/webcomponents-lite.js"></script>
 		<link rel="import" href="../iron-component-page/iron-component-page.html">
 	</head>


### PR DESCRIPTION
In the new rubrics creation component, we are using this component with titles with a larger font size. When the font size is greater than the icon size, it causes the icon and title for a given `d2l-accordion-collapse` item to become misaligned. The icon top-aligns to the containing div and sits too high relative to the title:
![icons-not-aligned](https://user-images.githubusercontent.com/32819802/48809275-cd85f700-ecd8-11e8-8beb-dd0d08ce2683.PNG)
Adding `align-items: center` via `--layout-center` fixes the issue:
![icon-center-aligned](https://user-images.githubusercontent.com/32819802/48809274-cced6080-ecd8-11e8-8b6b-e5ade83e9b12.PNG)