### PR TITLE
Fix Uncaught RangeError: Maximum call stack size exceeded.

### DIFF
--- a/d2l-accordion-collapse.js
+++ b/d2l-accordion-collapse.js
@@ -184,6 +184,9 @@ Polymer({
 		}
 	},
 	_notifyStateChanged: function() {
+		if (this.opened) {
+			this.fire('d2l-accordion-collapse-state-opened');
+		}
 		this.fire('d2l-accordion-collapse-state-changed', { opened: this.opened, el: this });
 		this.$.trigger.setAttribute('aria-expanded', this.opened);
 	},

--- a/d2l-accordion.js
+++ b/d2l-accordion.js
@@ -15,7 +15,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-accordion">
 	<slot></slot>
 	</template>
 
-	
+
 </dom-module>`;
 
 document.head.appendChild($_documentContainer.content);
@@ -48,7 +48,7 @@ Polymer({
 	],
 	ready: function() {
 		this.selectable = 'd2l-accordion-collapse';
-		this.activateEvent = 'd2l-accordion-collapse-state-changed';
+		this.activateEvent = 'd2l-accordion-collapse-state-opened';
 		this.selectedAttribute = 'opened';
 	}
 });


### PR DESCRIPTION
_notifyStateChanged was being called for every opened property change
rather than only when opened is set to true, which is what
iron selectable behavior expects

The following is a stacktrace showing the loop (note _notifyStateChanged)
```
_notifyStateChanged (d2l-accordion-collapse.js:196)
runObserverEffect (property-effects.js:227)
runEffectsForProperty (property-effects.js:168)
runEffects (property-effects.js:128)
_propertiesChanged (property-effects.js:1888)
_flushProperties (properties-changed.js:390)
_flushProperties (property-effects.js:1716)
_invalidateProperties (property-effects.js:1682)
_setProperty (property-effects.js:1666)
Object.defineProperty.set (properties-changed.js:163)
_attributeToProperty (properties-changed.js:498)
attributeChangedCallback (properties-changed.js:472)
attributeChangedCallback (legacy-element-mixin.js:161)
toggleAttribute (legacy-element-mixin.js:1003)
_applySelection (iron-selectable.js:360)
setItemSelected (iron-selection.js:82)
select (iron-selection.js:100)
_selectSelected (iron-selectable.js:302)
_updateSelected (iron-multi-selectable.js:95)
runMethodEffect (property-effects.js:917)
runEffectsForProperty (property-effects.js:168)
runEffects (property-effects.js:128)
_propertiesChanged (property-effects.js:1888)
_flushProperties (properties-changed.js:390)
_flushProperties (property-effects.js:1716)
_invalidateProperties (property-effects.js:1682)
_setProperty (property-effects.js:1666)
Object.defineProperty.set (properties-changed.js:163)
select (iron-multi-selectable.js:66)
_itemActivate (iron-selectable.js:412)
_activateHandler (iron-selectable.js:397)
handler (template-stamp.js:93)
fire (legacy-element-mixin.js:461)
_notifyStateChanged (d2l-accordion-collapse.js:196)
open (d2l-accordion-collapse.js:154)
toggle (d2l-accordion-collapse.js:175)
handler (template-stamp.js:93)
```

to reproduce the bug before the fix:
1. `polymer serve`
2. Open the demo/index.html page
3. Open the console
4. For the first snippet:
5. Open `Regular >`
6. Open `Flex`

Expected: No console errors
Actual: Uncaught RangeError: Maximum call stack size exceeded