### PR TITLE
Added a summary slot to the accordion for summarizing the content inside of it

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,18 @@ Example 4:
 </d2l-accordion-collapse>
 ```
 
+Example 5:
+```html
+<d2l-accordion-collapse flex border>
+	<h2 slot="header">Custom header, summary, border and flex 💪</h2>
+	<ul slot="summaryData" style="list-style-type: none; padding-left: 0px;">
+		<li>Availability starts 4/13/2020 and ends 4/23/2020</li>
+		<li>One release condition</li>
+		<li>Special access</li>
+	</ul>
+	<p>Stuff inside of the accordion goes here</p>
+</d2l-accordion-collapse>
+```
 ## Developing, Testing and Contributing
 
 After cloning the repo, run `npm install` to install dependencies.

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Polymer-based widget that displays a list of collapsible components. When collap
 
 #### Slots:
 * header - content to display under the title
+* summaryData - content that summarizes the data inside the accordion
 
 Example 1:
 ```html

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Polymer-based widget that displays a list of collapsible components. When collap
 
 #### Slots:
 * header - content to display under the title
-* summaryData - content that summarizes the data inside the accordion
+* summary - content that summarizes the data inside the accordion
 
 Example 1:
 ```html
@@ -68,7 +68,7 @@ Example 5:
 ```html
 <d2l-accordion-collapse flex border>
 	<h2 slot="header">Custom header, summary, border and flex 💪</h2>
-	<ul slot="summaryData" style="list-style-type: none; padding-left: 0px;">
+	<ul slot="summary" style="list-style-type: none; padding-left: 0px;">
 		<li>Availability starts 4/13/2020 and ends 4/23/2020</li>
 		<li>One release condition</li>
 		<li>Special access</li>

--- a/d2l-accordion-collapse.js
+++ b/d2l-accordion-collapse.js
@@ -45,11 +45,11 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-accordion-collapse">
 			}
 			.summary {
 				opacity: 1;
-				transition: opacity 200ms ease;
+				transition: opacity 900ms ease;
 			}
 
 			iron-collapse {
-				--iron-collapse-transition-duration: 1s;
+				--iron-collapse-transition-duration: 800ms;
 			}
 		</style>
 
@@ -177,9 +177,9 @@ Polymer({
 		}
 
 		var ironCollapse = this.shadowRoot.querySelector("#detail-collapse");
-		var isClosing = ironCollapse.transitioning === true && ironCollapse.opened === false;
+		var inTransition = ironCollapse.transitioning === true && ironCollapse.opened === false;
 
-		if(!isClosing){
+		if( !inTransition ){
 			var content = this.shadowRoot.querySelector(".content");
 			var summary = this.shadowRoot.querySelector('.summary');
 			content.style.minHeight = (content.offsetHeight - 2) + 'px';
@@ -194,7 +194,7 @@ Polymer({
 			return;
 		}
 		var summary = this.shadowRoot.querySelector('.summary');
-		summary.style.transitionDelay = '300ms';
+		summary.style.transitionDelay = '350ms';
 		this.opened = false;
 		this._notifyStateChanged();
 	},

--- a/d2l-accordion-collapse.js
+++ b/d2l-accordion-collapse.js
@@ -56,7 +56,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-accordion-collapse">
 			<div class="collapse-title" title="[[label]]" flex$=[[flex]]>[[title]][[label]]<slot name="header"></slot>
 			</div>
 			<template is="dom-if" if="[[!noIcons]]">
-				<d2l-icon class="icon" icon="[[_toggle(opened, collapseIcon, expandIcon)]]"></d2l-icon>
+				<d2l-icon icon="[[_toggle(opened, collapseIcon, expandIcon)]]"></d2l-icon>
 			</template>
 		</a>
 		<div class="content" opened$="[[opened]]">

--- a/d2l-accordion-collapse.js
+++ b/d2l-accordion-collapse.js
@@ -19,7 +19,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-accordion-collapse">
 				@apply --layout-center;
 				text-decoration: none;
 			}
-			#trigger[border] {
+			#trigger[data-border] {
 				border-bottom: solid 1px var(--d2l-color-corundum);
 				padding-bottom: 0.4rem;
 				margin-bottom: 0.4rem;
@@ -27,12 +27,10 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-accordion-collapse">
 			#trigger, #trigger:visited, #trigger:hover, #trigger:active {
 				color: inherit;
 			}
-			.collapse-title[flex] {
+			:host([flex]) .collapse-title {
 				@apply --layout-flex;
 			}
-			.collapse-title:not([flex]) {
-				margin-right: 0.3rem;
-			}
+		
 			.content {
 				height: auto;
 				padding: 1px;
@@ -40,32 +38,39 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-accordion-collapse">
 				position: relative;
 				overflow: hidden;
 			}
-			.content[opened] .summary {
+			.content[data-opened] .summary {
 				opacity: 0;
 			}
 			.summary {
 				opacity: 1;
 				transition: opacity 100ms ease;
+				transition-delay: 350ms;
 			}
 			iron-collapse {
 				--iron-collapse-transition-duration: 800ms;
 			}
+			:host([_state="closed"]) .content { 
+				min-height: 0;
+			}
+			:host([_state="closed"]) .summary { 
+				position: static;
+			}
 		</style>
 
-		<a href="javascript:void(0)" id="trigger" on-click="toggle" aria-controls="collapse" role="button" border$=[[border]]>
-			<div class="collapse-title" title="[[label]]" flex$=[[flex]]>[[title]][[label]]<slot name="header"></slot>
+		<a href="javascript:void(0)" id="trigger" on-click="toggle" aria-controls="collapse" role="button" data-border$="[[border]]">
+			<div class="collapse-title" title="[[label]]">[[title]][[label]]<slot name="header"></slot>
 			</div>
 			<template is="dom-if" if="[[!noIcons]]">
 				<d2l-icon icon="[[_toggle(opened, collapseIcon, expandIcon)]]"></d2l-icon>
 			</template>
 		</a>
-		<div class="content" opened$="[[opened]]">
+		<div class="content" data-opened$="[[opened]]">
 			<iron-collapse id="detail" class="detail" no-animation="[[noAnimation]]" opened="[[opened]]" on-transitioning-changed="_handleTransitionChanged">
 				<slot></slot>
 			</iron-collapse>
 			<div class="summary">
 				<slot name="summaryData"></slot>
-			</div
+			</div>
 		</div>
 	</template>
 </dom-module>`;
@@ -186,12 +191,12 @@ Polymer({
 			return;
 		}
 
-		var ironCollapse = this.shadowRoot.querySelector('#detail');
-		var inTransition = ironCollapse.transitioning === true && ironCollapse.opened === false;
+		const ironCollapse = this.$.detail;
+		const inTransition = ironCollapse.transitioning === true && ironCollapse.opened === false;
 
 		if (!inTransition) {
-			var content = this.shadowRoot.querySelector('.content');
-			var summary = this.shadowRoot.querySelector('.summary');
+			const content = this.shadowRoot.querySelector('.content');
+			const summary = this.shadowRoot.querySelector('.summary');
 			content.style.minHeight = (content.offsetHeight - 2) + 'px';
 			summary.style.position = 'absolute';
 			summary.style.transitionDelay = '0ms';
@@ -203,8 +208,6 @@ Polymer({
 		if (this.disabled) {
 			return;
 		}
-		var summary = this.shadowRoot.querySelector('.summary');
-		summary.style.transitionDelay = '350ms';
 		this.opened = false;
 		this._notifyStateChanged();
 	},
@@ -224,10 +227,10 @@ Polymer({
 			event.target.opened === false &&
 			event.target.transitioning === false;
 		if (isClosed) {
-			var content = this.shadowRoot.querySelector('.content');
-			var summary = this.shadowRoot.querySelector('.summary');
-			content.style.minHeight = '0px';
-			summary.style.position = 'static';
+			const content = this.shadowRoot.querySelector('.content');
+			const summary = this.shadowRoot.querySelector('.summary');
+			content.style.setProperty("closed", true);
+			summary.style.setProperty("closed", true);
 		}
 	},
 	_toggle: function(cond, t, f) { return cond ? t : f; },

--- a/d2l-accordion-collapse.js
+++ b/d2l-accordion-collapse.js
@@ -30,17 +30,20 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-accordion-collapse">
 				padding-left: 1rem;
 				border-bottom: solid 1px var(--d2l-color-corundum);
 			}
-			::slotted([slot=summary]) {
-				padding-top: 1rem;
-				color: var(--d2l-color-tungsten);
-				list-style-type: none;
-				padding-left: 1rem;
-			}
 			#trigger d2l-icon { 
 				@apply --layout-self-start;
 			}
-			.icon {
-				background-color: red;
+			.content {
+				height: auto;
+				padding: 1px;
+				margin: -1px;
+			}
+			.content[opened] .summary {
+				display: none;
+				position: absolute;
+			}
+			.content .summary {
+				transition: all 300ms cubic-bezier(0.335, 0.010, 0.030, 1.360);
 			}
 		</style>
 
@@ -51,12 +54,14 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-accordion-collapse">
 				<d2l-icon class="icon" icon="[[_toggle(opened, collapseIcon, expandIcon)]]"></d2l-icon>
 			</template>
 		</a>
-		<iron-collapse id="collapse" no-animation="[[noAnimation]]" opened="[[opened]]">
-			<slot></slot>
-		</iron-collapse>
-		<iron-collapse no-animation="[[noAnimation]]" opened="[[!opened]]">
-			<slot class="summary" name="summary"></slot>
-		</iron-collapse>
+		<div class="content" opened$="[[opened]]" >
+			<iron-collapse class="detail" no-animation="[[noAnimation]]" opened="[[opened]]">
+				<slot></slot>
+			</iron-collapse>
+			<div class="summary">
+				<slot name="summaryData"></slot>
+			</div
+		</div>
 	</template>
 </dom-module>`;
 
@@ -153,21 +158,20 @@ Polymer({
 		if (this.disabled) {
 			return;
 		}
-		window.addEventListener('d2l-accordion-collapse-state-changed', this._boundListener);
-		this.$.collapse.addEventListener('iron-resize', this._fireAccordionResizeEvent);
 	},
 
 	detached: function() {
 		if (this.disabled) {
 			return;
 		}
-		window.removeEventListener('d2l-accordion-collapse-state-changed', this._boundListener);
-		this.$.collapse.removeEventListener('iron-resize', this._fireAccordionResizeEvent);
 	},
 	open: function() {
 		if (this.disabled) {
 			return;
 		}
+		var butts = this.shadowRoot.querySelector(".content");
+		this.minHeight = butts.offsetHeight - 2;
+		butts.style.minHeight = this.minHeight + 'px';
 		this.opened = true;
 		this._notifyStateChanged();
 	},

--- a/d2l-accordion-collapse.js
+++ b/d2l-accordion-collapse.js
@@ -1,6 +1,5 @@
 import '@polymer/polymer/polymer-legacy.js';
 import 'd2l-colors/d2l-colors.js';
-import { heading2Styles } from '@brightspace-ui/core/components/typography/styles.js';
 import 'd2l-icons/d2l-icon.js';
 import 'd2l-icons/tier1-icons.js';
 import '@polymer/iron-collapse/iron-collapse.js';
@@ -45,7 +44,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-accordion-collapse">
 			}
 			.summary {
 				opacity: 1;
-				transition: opacity 900ms ease;
+				transition: opacity 100ms ease;
 			}
 
 			iron-collapse {
@@ -61,7 +60,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-accordion-collapse">
 			</template>
 		</a>
 		<div class="content" opened$="[[opened]]">
-			<iron-collapse id="detail-collapse" class="detail" no-animation="[[noAnimation]]" opened="[[opened]]" on-transitioning-changed="_handleTransitionChanged">
+			<iron-collapse id="detail" class="detail" no-animation="[[noAnimation]]" opened="[[opened]]" on-transitioning-changed="_handleTransitionChanged">
 				<slot></slot>
 			</iron-collapse>
 			<div class="summary">
@@ -164,19 +163,23 @@ Polymer({
 		if (this.disabled) {
 			return;
 		}
+		window.addEventListener('d2l-accordion-collapse-state-changed', this._boundListener);
+		this.$.detail.addEventListener('iron-resize', this._fireAccordionResizeEvent);
 	},
 
 	detached: function() {
 		if (this.disabled) {
 			return;
 		}
+		window.removeEventListener('d2l-accordion-collapse-state-changed', this._boundListener);
+		this.$.detail.removeEventListener('iron-resize', this._fireAccordionResizeEvent);
 	},
 	open: function() {
 		if (this.disabled) {
 			return;
 		}
 
-		var ironCollapse = this.shadowRoot.querySelector("#detail-collapse");
+		var ironCollapse = this.shadowRoot.querySelector("#detail");
 		var inTransition = ironCollapse.transitioning === true && ironCollapse.opened === false;
 
 		if( !inTransition ){

--- a/d2l-accordion-collapse.js
+++ b/d2l-accordion-collapse.js
@@ -71,7 +71,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-accordion-collapse">
 				<slot></slot>
 			</iron-collapse>
 			<div class="summary">
-				<slot name="summaryData"></slot>
+				<slot name="summary"></slot>
 			</div>
 		</div>
 	</template>

--- a/d2l-accordion-collapse.js
+++ b/d2l-accordion-collapse.js
@@ -1,5 +1,6 @@
 import '@polymer/polymer/polymer-legacy.js';
 import 'd2l-colors/d2l-colors.js';
+import { heading2Styles } from '@brightspace-ui/core/components/typography/styles.js';
 import 'd2l-icons/d2l-icon.js';
 import 'd2l-icons/tier1-icons.js';
 import '@polymer/iron-collapse/iron-collapse.js';
@@ -25,6 +26,21 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-accordion-collapse">
 			.collapse-title[flex] {
 				@apply --layout-flex;
 			}
+			.collapse-title {
+				padding-left: 1rem;
+			}
+			::slotted([slot=summary]) {
+				padding-top: 1rem;
+				border-top: solid 1px var(--d2l-color-corundum);
+				color: var(--d2l-color-tungsten);
+				list-style-type: none;
+			}
+			::slotted(*){
+				padding-left: 1rem;
+			}
+			#trigger d2l-icon { 
+				@apply --layout-self-start;
+			}
 		</style>
 
 		<a href="javascript:void(0)" id="trigger" on-click="toggle" aria-controls="collapse" role="button">
@@ -34,6 +50,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-accordion-collapse">
 				<d2l-icon icon="[[_toggle(opened, collapseIcon, expandIcon)]]"></d2l-icon>
 			</template>
 		</a>
+		<slot name="summary" display="[[opened]]"></slot>
 		<iron-collapse id="collapse" no-animation="[[noAnimation]]" opened="[[opened]]">
 			<slot></slot>
 		</iron-collapse>

--- a/d2l-accordion-collapse.js
+++ b/d2l-accordion-collapse.js
@@ -229,8 +229,8 @@ Polymer({
 		if (isClosed) {
 			const content = this.shadowRoot.querySelector('.content');
 			const summary = this.shadowRoot.querySelector('.summary');
-			content.style.setProperty("closed", true);
-			summary.style.setProperty("closed", true);
+			content.style.setProperty('closed', true);
+			summary.style.setProperty('closed', true);
 		}
 	},
 	_toggle: function(cond, t, f) { return cond ? t : f; },

--- a/d2l-accordion-collapse.js
+++ b/d2l-accordion-collapse.js
@@ -231,15 +231,15 @@ Polymer({
 		}
 	},
 	_handleTransitionChanged(event) {
-		const isClosed = 
+		const isClosed =
 			event.target.opened === false && event.target.transitioning === false;
-		const isOpened = 
+		const isOpened =
 			event.target.opened === true && event.target.transitioning === false;
 		if (isClosed) {
 			this._state = 'closed';
 			const content = this.shadowRoot.querySelector('.content');
 			content.style.minHeight = 0;
-		}else if(isOpened){
+		} else if (isOpened) {
 			this._state = 'opened';
 		}
 	},

--- a/d2l-accordion-collapse.js
+++ b/d2l-accordion-collapse.js
@@ -223,7 +223,7 @@ Polymer({
 		}
 	},
 	_handleTransitionChanged(event) {
-		var isClosed =
+		const isClosed =
 			event.target.opened === false &&
 			event.target.transitioning === false;
 		if (isClosed) {

--- a/d2l-accordion-collapse.js
+++ b/d2l-accordion-collapse.js
@@ -45,11 +45,11 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-accordion-collapse">
 			}
 			.summary {
 				opacity: 1;
-				transition: opacity 500ms ease;
+				transition: opacity 200ms ease;
 			}
 
 			iron-collapse {
-				--iron-collapse-transition-duration: 2s;
+				--iron-collapse-transition-duration: 1s;
 			}
 		</style>
 
@@ -61,7 +61,7 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-accordion-collapse">
 			</template>
 		</a>
 		<div class="content" opened$="[[opened]]">
-			<iron-collapse class="detail" no-animation="[[noAnimation]]" opened="[[opened]]" on-transitioning-changed="_handleTransitionChanged">
+			<iron-collapse id="detail-collapse" class="detail" no-animation="[[noAnimation]]" opened="[[opened]]" on-transitioning-changed="_handleTransitionChanged">
 				<slot></slot>
 			</iron-collapse>
 			<div class="summary">
@@ -175,11 +175,17 @@ Polymer({
 		if (this.disabled) {
 			return;
 		}
-		var content = this.shadowRoot.querySelector(".content");
-		var summary = this.shadowRoot.querySelector('.summary');
-		content.style.minHeight = (content.offsetHeight - 2) + 'px';
-		summary.style.position = 'absolute';
-		summary.style.transitionDelay = '0ms';
+
+		var ironCollapse = this.shadowRoot.querySelector("#detail-collapse");
+		var isClosing = ironCollapse.transitioning === true && ironCollapse.opened === false;
+
+		if(!isClosing){
+			var content = this.shadowRoot.querySelector(".content");
+			var summary = this.shadowRoot.querySelector('.summary');
+			content.style.minHeight = (content.offsetHeight - 2) + 'px';
+			summary.style.position = 'absolute';
+			summary.style.transitionDelay = '0ms';
+		}
 		this.opened = true;
 		this._notifyStateChanged();
 	},
@@ -188,7 +194,7 @@ Polymer({
 			return;
 		}
 		var summary = this.shadowRoot.querySelector('.summary');
-		summary.style.transitionDelay = '1000ms';
+		summary.style.transitionDelay = '300ms';
 		this.opened = false;
 		this._notifyStateChanged();
 	},

--- a/d2l-accordion-collapse.js
+++ b/d2l-accordion-collapse.js
@@ -37,13 +37,19 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-accordion-collapse">
 				height: auto;
 				padding: 1px;
 				margin: -1px;
+				position: relative;
+				overflow: hidden;
 			}
 			.content[opened] .summary {
-				display: none;
-				position: absolute;
+				opacity: 0;
 			}
-			.content .summary {
-				transition: all 300ms cubic-bezier(0.335, 0.010, 0.030, 1.360);
+			.summary {
+				opacity: 1;
+				transition: opacity 500ms ease;
+			}
+
+			iron-collapse {
+				--iron-collapse-transition-duration: 2s;
 			}
 		</style>
 
@@ -54,8 +60,8 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-accordion-collapse">
 				<d2l-icon class="icon" icon="[[_toggle(opened, collapseIcon, expandIcon)]]"></d2l-icon>
 			</template>
 		</a>
-		<div class="content" opened$="[[opened]]" >
-			<iron-collapse class="detail" no-animation="[[noAnimation]]" opened="[[opened]]">
+		<div class="content" opened$="[[opened]]">
+			<iron-collapse class="detail" no-animation="[[noAnimation]]" opened="[[opened]]" on-transitioning-changed="_handleTransitionChanged">
 				<slot></slot>
 			</iron-collapse>
 			<div class="summary">
@@ -169,9 +175,11 @@ Polymer({
 		if (this.disabled) {
 			return;
 		}
-		var butts = this.shadowRoot.querySelector(".content");
-		this.minHeight = butts.offsetHeight - 2;
-		butts.style.minHeight = this.minHeight + 'px';
+		var content = this.shadowRoot.querySelector(".content");
+		var summary = this.shadowRoot.querySelector('.summary');
+		content.style.minHeight = (content.offsetHeight - 2) + 'px';
+		summary.style.position = 'absolute';
+		summary.style.transitionDelay = '0ms';
 		this.opened = true;
 		this._notifyStateChanged();
 	},
@@ -179,6 +187,8 @@ Polymer({
 		if (this.disabled) {
 			return;
 		}
+		var summary = this.shadowRoot.querySelector('.summary');
+		summary.style.transitionDelay = '1000ms';
 		this.opened = false;
 		this._notifyStateChanged();
 	},
@@ -191,6 +201,17 @@ Polymer({
 			this.close();
 		} else {
 			this.open();
+		}
+	},
+	_handleTransitionChanged(event) {
+		var isClosed =
+			event.target.opened === false &&
+			event.target.transitioning === false;
+		if( isClosed ) {
+			var content = this.shadowRoot.querySelector(".content");
+			var summary = this.shadowRoot.querySelector('.summary');
+			content.style.minHeight = '0px';
+			summary.style.position = 'static';
 		}
 	},
 	_toggle: function(cond, t, f) { return cond ? t : f; },

--- a/d2l-accordion-collapse.js
+++ b/d2l-accordion-collapse.js
@@ -30,7 +30,6 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-accordion-collapse">
 			:host([flex]) .collapse-title {
 				@apply --layout-flex;
 			}
-		
 			.content {
 				height: auto;
 				padding: 1px;
@@ -43,17 +42,20 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-accordion-collapse">
 			}
 			.summary {
 				opacity: 1;
-				transition: opacity 100ms ease;
-				transition-delay: 350ms;
+				transition: opacity 300ms ease;
 			}
 			iron-collapse {
-				--iron-collapse-transition-duration: 800ms;
+				--iron-collapse-transition-duration: 1000ms;
 			}
 			:host([_state="closed"]) .content { 
 				min-height: 0;
 			}
 			:host([_state="closed"]) .summary { 
 				position: static;
+			}
+			:host([_state="opened"]) .summary { 
+				position: absolute;
+				transition-delay: 0;
 			}
 		</style>
 
@@ -164,6 +166,14 @@ Polymer({
 		 */
 		_boundListener: {
 			type: Function
+		},
+		/**
+		 * The current state of the accordion (opened, closed)
+		 */
+		_state: {
+			type: String,
+			reflectToAttribute: true,
+			value: 'closed'
 		}
 	},
 	ready: function() {
@@ -196,10 +206,8 @@ Polymer({
 
 		if (!inTransition) {
 			const content = this.shadowRoot.querySelector('.content');
-			const summary = this.shadowRoot.querySelector('.summary');
 			content.style.minHeight = (content.offsetHeight - 2) + 'px';
-			summary.style.position = 'absolute';
-			summary.style.transitionDelay = '0ms';
+			this._state = 'opened';
 		}
 		this.opened = true;
 		this._notifyStateChanged();
@@ -223,14 +231,16 @@ Polymer({
 		}
 	},
 	_handleTransitionChanged(event) {
-		const isClosed =
-			event.target.opened === false &&
-			event.target.transitioning === false;
+		const isClosed = 
+			event.target.opened === false && event.target.transitioning === false;
+		const isOpened = 
+			event.target.opened === true && event.target.transitioning === false;
 		if (isClosed) {
+			this._state = 'closed';
 			const content = this.shadowRoot.querySelector('.content');
-			const summary = this.shadowRoot.querySelector('.summary');
-			content.style.setProperty('closed', true);
-			summary.style.setProperty('closed', true);
+			content.style.minHeight = 0;
+		}else if(isOpened){
+			this._state = 'opened';
 		}
 	},
 	_toggle: function(cond, t, f) { return cond ? t : f; },

--- a/d2l-accordion-collapse.js
+++ b/d2l-accordion-collapse.js
@@ -28,18 +28,19 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-accordion-collapse">
 			}
 			.collapse-title {
 				padding-left: 1rem;
+				border-bottom: solid 1px var(--d2l-color-corundum);
 			}
 			::slotted([slot=summary]) {
 				padding-top: 1rem;
-				border-top: solid 1px var(--d2l-color-corundum);
 				color: var(--d2l-color-tungsten);
 				list-style-type: none;
-			}
-			::slotted(*){
 				padding-left: 1rem;
 			}
 			#trigger d2l-icon { 
 				@apply --layout-self-start;
+			}
+			.icon {
+				background-color: red;
 			}
 		</style>
 
@@ -47,12 +48,14 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-accordion-collapse">
 			<div class="collapse-title" title="[[label]]" flex$=[[flex]]>[[title]][[label]]<slot name="header"></slot>
 			</div>
 			<template is="dom-if" if="[[!noIcons]]">
-				<d2l-icon icon="[[_toggle(opened, collapseIcon, expandIcon)]]"></d2l-icon>
+				<d2l-icon class="icon" icon="[[_toggle(opened, collapseIcon, expandIcon)]]"></d2l-icon>
 			</template>
 		</a>
-		<slot name="summary" display="[[opened]]"></slot>
 		<iron-collapse id="collapse" no-animation="[[noAnimation]]" opened="[[opened]]">
 			<slot></slot>
+		</iron-collapse>
+		<iron-collapse no-animation="[[noAnimation]]" opened="[[!opened]]">
+			<slot class="summary" name="summary"></slot>
 		</iron-collapse>
 	</template>
 </dom-module>`;

--- a/d2l-accordion-collapse.js
+++ b/d2l-accordion-collapse.js
@@ -19,18 +19,19 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-accordion-collapse">
 				@apply --layout-center;
 				text-decoration: none;
 			}
+			#trigger[border] {
+				border-bottom: solid 1px var(--d2l-color-corundum);
+				padding-bottom: 0.4rem;
+				margin-bottom: 0.4rem;
+			}
 			#trigger, #trigger:visited, #trigger:hover, #trigger:active {
 				color: inherit;
 			}
 			.collapse-title[flex] {
 				@apply --layout-flex;
 			}
-			.collapse-title {
-				padding-left: 1rem;
-				border-bottom: solid 1px var(--d2l-color-corundum);
-			}
-			#trigger d2l-icon { 
-				@apply --layout-self-start;
+			.collapse-title:not([flex]) {
+				margin-right: 0.3rem;
 			}
 			.content {
 				height: auto;
@@ -46,13 +47,12 @@ $_documentContainer.innerHTML = `<dom-module id="d2l-accordion-collapse">
 				opacity: 1;
 				transition: opacity 100ms ease;
 			}
-
 			iron-collapse {
 				--iron-collapse-transition-duration: 800ms;
 			}
 		</style>
 
-		<a href="javascript:void(0)" id="trigger" on-click="toggle" aria-controls="collapse" role="button">
+		<a href="javascript:void(0)" id="trigger" on-click="toggle" aria-controls="collapse" role="button" border$=[[border]]>
 			<div class="collapse-title" title="[[label]]" flex$=[[flex]]>[[title]][[label]]<slot name="header"></slot>
 			</div>
 			<template is="dom-if" if="[[!noIcons]]">
@@ -134,9 +134,16 @@ Polymer({
 			value: false
 		},
 		/**
-		 * Whether to use or not flex layout.
+		 * Whether or not to use flex layout.
 		 */
 		flex: {
+			type: Boolean,
+			value: false
+		},
+		/**
+		 * Whether or not to add a border between the header and the content.
+		 */
+		border: {
 			type: Boolean,
 			value: false
 		},
@@ -179,11 +186,11 @@ Polymer({
 			return;
 		}
 
-		var ironCollapse = this.shadowRoot.querySelector("#detail");
+		var ironCollapse = this.shadowRoot.querySelector('#detail');
 		var inTransition = ironCollapse.transitioning === true && ironCollapse.opened === false;
 
-		if( !inTransition ){
-			var content = this.shadowRoot.querySelector(".content");
+		if (!inTransition) {
+			var content = this.shadowRoot.querySelector('.content');
 			var summary = this.shadowRoot.querySelector('.summary');
 			content.style.minHeight = (content.offsetHeight - 2) + 'px';
 			summary.style.position = 'absolute';
@@ -216,8 +223,8 @@ Polymer({
 		var isClosed =
 			event.target.opened === false &&
 			event.target.transitioning === false;
-		if( isClosed ) {
-			var content = this.shadowRoot.querySelector(".content");
+		if (isClosed) {
+			var content = this.shadowRoot.querySelector('.content');
 			var summary = this.shadowRoot.querySelector('.summary');
 			content.style.minHeight = '0px';
 			summary.style.position = 'static';

--- a/demo/d2l-accordion-collapse.html
+++ b/demo/d2l-accordion-collapse.html
@@ -38,6 +38,19 @@ $_documentContainer.innerHTML = `<demo-snippet>
 
 document.body.appendChild($_documentContainer.content);
 </script>
+<script type="module">
+	const $_documentContainer = document.createElement('template');
+	
+	$_documentContainer.innerHTML = `<demo-snippet>
+				<template>
+					<d2l-accordion-collapse title="Regular with border" opened="" border>
+						Demo
+					</d2l-accordion-collapse>
+				</template>
+			</demo-snippet>`;
+	
+	document.body.appendChild($_documentContainer.content);
+	</script>
 		<script type="module">
 const $_documentContainer = document.createElement('template');
 
@@ -190,9 +203,32 @@ document.body.appendChild($_documentContainer.content);
 	
 	$_documentContainer.innerHTML = `<demo-snippet>
 		<template>
-			<d2l-accordion-collapse flex>
-				<h2 slot="header">Custom header, summary and flex</h2>
+			<d2l-accordion-collapse label="Summary and flex" flex>
 				<ul slot="summaryData">
+					<li>Availability starts 4/13/2020 and ends 4/23/2020</li>
+					<li>One release condition</li>
+					<li>Special access</li>
+				</ul>
+				<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus lectus erat, dignissim quis efficitur non, iaculis nec ante. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Aliquam fringilla eu orci sed tristique. Aliquam pellentesque turpis ut vehicula volutpat. Quisque euismod felis nec dolor scelerisque, ullamcorper gravida ante suscipit. Nam eget libero vel mauris tincidunt molestie. Maecenas tortor purus, sodales vel lacus vel, molestie tempor tellus.
+
+Proin eget accumsan neque. Vestibulum semper justo erat, vitae scelerisque neque sollicitudin eget. Suspendisse vulputate vel risus sit amet vehicula. In diam orci, convallis sed elementum ut, gravida at risus. Phasellus posuere erat eu pulvinar congue. Praesent nibh nibh, tempor in ultricies et, vestibulum nec urna. Cras varius vestibulum velit, porttitor venenatis mi iaculis vel. Etiam eget eleifend metus. Donec ac nisl condimentum, venenatis massa eu, sodales quam. Aliquam egestas metus vel magna blandit placerat. Nullam gravida ultrices sapien, eget aliquet lorem gravida sed. Pellentesque ut euismod orci, at vestibulum velit. Nam faucibus sagittis aliquam. Suspendisse et libero id elit interdum eleifend. In ac nisi quis est laoreet semper. Nam eget scelerisque arcu, a pretium libero.
+
+Maecenas sed tortor ac risus consectetur viverra ac sit amet purus. In tempor scelerisque augue in pretium. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Nam nulla sapien, porttitor a blandit quis, convallis blandit justo. Sed luctus vitae nisl a consectetur. Proin interdum orci ex, non sodales diam faucibus in. Fusce et dolor ac ipsum vulputate pretium. Quisque nec vehicula quam.
+</p>
+			</d2l-accordion-collapse>
+		</template>
+	</demo-snippet>`;
+	
+	document.body.appendChild($_documentContainer.content);
+	</script>
+<script type="module">
+	const $_documentContainer = document.createElement('template');
+	
+	$_documentContainer.innerHTML = `<demo-snippet>
+		<template>
+			<d2l-accordion-collapse flex border>
+				<h2 slot="header">Custom header, summary, border and flex 💪</h2>
+				<ul slot="summaryData" style="list-style-type: none; padding-left: 0px;">
 					<li>Availability starts 4/13/2020 and ends 4/23/2020</li>
 					<li>One release condition</li>
 					<li>Special access</li>

--- a/demo/d2l-accordion-collapse.html
+++ b/demo/d2l-accordion-collapse.html
@@ -185,5 +185,23 @@ $_documentContainer.innerHTML = `<demo-snippet>
 
 document.body.appendChild($_documentContainer.content);
 </script>
+<script type="module">
+	const $_documentContainer = document.createElement('template');
+	
+	$_documentContainer.innerHTML = `<demo-snippet>
+		<template>
+			<d2l-accordion-collapse title="Summary and flex" flex>
+				<ul slot="summary">
+					<li>Availability starts 4/13/2020 and ends 4/23/2020</li>
+					<li>One release condition</li>
+					<li>Special access</li>
+				</ul>
+				Demo
+			</d2l-accordion-collapse>
+		</template>
+	</demo-snippet>`;
+	
+	document.body.appendChild($_documentContainer.content);
+	</script>
 	</body>
 </html>

--- a/demo/d2l-accordion-collapse.html
+++ b/demo/d2l-accordion-collapse.html
@@ -192,7 +192,7 @@ document.body.appendChild($_documentContainer.content);
 		<template>
 			<d2l-accordion-collapse flex>
 				<h2 slot="header">Custom header, summary and flex</h2>
-				<ul slot="summary">
+				<ul slot="summaryData">
 					<li>Availability starts 4/13/2020 and ends 4/23/2020</li>
 					<li>One release condition</li>
 					<li>Special access</li>

--- a/demo/d2l-accordion-collapse.html
+++ b/demo/d2l-accordion-collapse.html
@@ -204,7 +204,7 @@ document.body.appendChild($_documentContainer.content);
 	$_documentContainer.innerHTML = `<demo-snippet>
 		<template>
 			<d2l-accordion-collapse label="Summary and flex" flex>
-				<ul slot="summaryData">
+				<ul slot="summary">
 					<li>Availability starts 4/13/2020 and ends 4/23/2020</li>
 					<li>One release condition</li>
 					<li>Special access</li>
@@ -228,7 +228,7 @@ Maecenas sed tortor ac risus consectetur viverra ac sit amet purus. In tempor sc
 		<template>
 			<d2l-accordion-collapse flex border>
 				<h2 slot="header">Custom header, summary, border and flex 💪</h2>
-				<ul slot="summaryData" style="list-style-type: none; padding-left: 0px;">
+				<ul slot="summary" style="list-style-type: none; padding-left: 0px;">
 					<li>Availability starts 4/13/2020 and ends 4/23/2020</li>
 					<li>One release condition</li>
 					<li>Special access</li>

--- a/demo/d2l-accordion-collapse.html
+++ b/demo/d2l-accordion-collapse.html
@@ -190,13 +190,19 @@ document.body.appendChild($_documentContainer.content);
 	
 	$_documentContainer.innerHTML = `<demo-snippet>
 		<template>
-			<d2l-accordion-collapse title="Summary and flex" flex>
+			<d2l-accordion-collapse flex>
+				<h2 slot="header">Custom header, summary and flex</h2>
 				<ul slot="summary">
 					<li>Availability starts 4/13/2020 and ends 4/23/2020</li>
 					<li>One release condition</li>
 					<li>Special access</li>
 				</ul>
-				Demo
+				<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus lectus erat, dignissim quis efficitur non, iaculis nec ante. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas. Aliquam fringilla eu orci sed tristique. Aliquam pellentesque turpis ut vehicula volutpat. Quisque euismod felis nec dolor scelerisque, ullamcorper gravida ante suscipit. Nam eget libero vel mauris tincidunt molestie. Maecenas tortor purus, sodales vel lacus vel, molestie tempor tellus.
+
+Proin eget accumsan neque. Vestibulum semper justo erat, vitae scelerisque neque sollicitudin eget. Suspendisse vulputate vel risus sit amet vehicula. In diam orci, convallis sed elementum ut, gravida at risus. Phasellus posuere erat eu pulvinar congue. Praesent nibh nibh, tempor in ultricies et, vestibulum nec urna. Cras varius vestibulum velit, porttitor venenatis mi iaculis vel. Etiam eget eleifend metus. Donec ac nisl condimentum, venenatis massa eu, sodales quam. Aliquam egestas metus vel magna blandit placerat. Nullam gravida ultrices sapien, eget aliquet lorem gravida sed. Pellentesque ut euismod orci, at vestibulum velit. Nam faucibus sagittis aliquam. Suspendisse et libero id elit interdum eleifend. In ac nisi quis est laoreet semper. Nam eget scelerisque arcu, a pretium libero.
+
+Maecenas sed tortor ac risus consectetur viverra ac sit amet purus. In tempor scelerisque augue in pretium. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. Nam nulla sapien, porttitor a blandit quis, convallis blandit justo. Sed luctus vitae nisl a consectetur. Proin interdum orci ex, non sodales diam faucibus in. Fusce et dolor ac ipsum vulputate pretium. Quisque nec vehicula quam.
+</p>
 			</d2l-accordion-collapse>
 		</template>
 	</demo-snippet>`;


### PR DESCRIPTION
Added a summary slot to allow for a summary to be provided for the content contained within the accordion. Also added a transition animation for the accordion that fades the summary in/out when it is opened/closed.

### Accordion when it is closed:
![accordion-closed-with-summary](https://user-images.githubusercontent.com/2337524/72638240-0c412c80-3931-11ea-8dc7-dd12f53e9d2f.png)

### Accordion when it is opened (summary is now hidden):
![accordion-opened-with-summary](https://user-images.githubusercontent.com/2337524/72638303-2bd85500-3931-11ea-8893-1fc2284a79b9.png)
